### PR TITLE
Added NUnit 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ script:
   - sudo mv ./xcopy /bin
   - msbuild /p:Configuration=Release CLI/CLI.csproj
   - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
+  - cp Engine/Resources/Translations/NaturalDocs.Engine.default.txt ./Engine.Tests/bin/Release
   - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ script:
   - sudo mv ./xcopy /bin
   - msbuild /p:Configuration=Release CLI/CLI.csproj
   - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
-  - cp Engine/Resources/Translations/NaturalDocs.Engine.default.txt ./Engine.Tests/bin/Release
+  - cp Engine/Resources/Translations/NaturalDocs.Engine.default.txt ./Engine.Tests/bin/Release/Translations
   - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ script:
   - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
   - cp Engine/Resources/Translations/NaturalDocs.Engine.default.txt ./Engine.Tests/bin/Release/Translations
   - cp -r Engine/Resources/Config Engine.Tests/bin/Release/
+  - cp -r Engine/Resources/Styles Engine.Tests/bin/Release/
   - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - sudo mv ./xcopy /bin
   - msbuild /p:Configuration=Release CLI/CLI.csproj
   - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
-  - cp Engine/Resources/Translations/NaturalDocs.Engine.default.txt ./Engine.Tests/bin/Release/Translations
+  - cp -r Engine/Resources/Translations Engine.Tests/bin/Release/
   - cp -r Engine/Resources/Config Engine.Tests/bin/Release/
   - cp -r Engine/Resources/Styles Engine.Tests/bin/Release/
   - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: csharp
 mono:
   - latest
+install:
+  - nuget install NUnit.Console -Version 3.9.0 -OutputDirectory testrunner
 script:
   - echo '#!/bin/bash' > ./xcopy
   - echo 'cp -r $1 $2' >> ./xcopy

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ script:
   - msbuild /p:Configuration=Release CLI/CLI.csproj
   - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
   - cp Engine/Resources/Translations/NaturalDocs.Engine.default.txt ./Engine.Tests/bin/Release/Translations
+  - cp -r Engine/Resources/Config Engine.Tests/bin/Release/
   - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ script:
   - sudo chmod 777 ./xcopy
   - sudo mv ./xcopy /bin
   - msbuild /p:Configuration=Release CLI/CLI.csproj
+  - msbuild /p:Configuration=Release Engine.Tests/Engine.Tests.csproj
+  - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./Engine.Tests/bin/Release/NaturalDocs.Engine.Tests.dll


### PR DESCRIPTION
The CI Branch now runs the NUnit tests that are specified in Engine.Tests. I order to get it to work, I had to manually copy several files from the Engine codebase to the compiled Engine.Tests codespace. Is this something that the build scripts should do?